### PR TITLE
Check dooneevent() return value explicitly

### DIFF
--- a/async_tkinter_loop.py
+++ b/async_tkinter_loop.py
@@ -15,7 +15,7 @@ async def main_loop(root: tkinter.Tk) -> None:
     """
     while True:
         # Process all pending events
-        while root.dooneevent(_tkinter.DONT_WAIT):
+        while root.dooneevent(_tkinter.DONT_WAIT) > 0:
             pass
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-tkinter-loop"
-version = "0.8.0"
+version = "0.8.1"
 description = "Asynchronous mainloop implementation for tkinter"
 authors = ["insolor <insolor@gmail.com>"]
 license = "MIT"

--- a/tests/test_async_tk_loop.py
+++ b/tests/test_async_tk_loop.py
@@ -6,7 +6,7 @@ from tkinter import Tk
 
 from async_tkinter_loop import async_handler, async_mainloop
 
-TIMEOUT = 30
+TIMEOUT = 60
 
 
 @pytest.mark.timeout(TIMEOUT)


### PR DESCRIPTION
In some cases dooneevent returns negative values (see https://github.com/python/cpython/blob/f63002755d3b7c0bb2e452f158769f19fcf3b850/Modules/_tkinter.c#L2694-L2724), which is a truthy value, so it's necessary to explicitely check, if the returned value is positive.