### PR TITLE
Derive the sleep time from the Tk settings

### DIFF
--- a/async_tkinter_loop/async_tkinter_loop.py
+++ b/async_tkinter_loop/async_tkinter_loop.py
@@ -26,7 +26,8 @@ async def main_loop(root: tk.Tk) -> None:
         except tk.TclError:
             break
 
-        await asyncio.sleep(0.01)
+        interval_ms = tk._tkinter.getbusywaitinterval()
+        await asyncio.sleep(interval_ms / 1000)
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:


### PR DESCRIPTION
Hi, it's me again. I found another thing which might be worth improving.

The Tk main loop defines its sleep time via the parameter "getbusywaitinterval".

We could adjust our waiting time to that value (whose default is 20 ms and which can be configured) instead of using 10 ms as a fixed value.

The downside is that it uses an internal/"private" component, the C module _tkinter.

If you think that is reasonable anyway, feel free to accept this pull request (in this case maybe pull suggestion?), if you don't like messing around with Tk's internal belongings (_tkinter), that's fine as well. Maybe we could have an own setting for that interval (or we just let it as it is).