### PR TITLE
Derive the sleep time from the Tk settings (2nd attempt)

### DIFF
--- a/async_tkinter_loop/async_tkinter_loop.py
+++ b/async_tkinter_loop/async_tkinter_loop.py
@@ -26,7 +26,8 @@ async def main_loop(root: tk.Tk) -> None:
         except tk.TclError:
             break
 
-        await asyncio.sleep(0.01)
+        interval_ms = _tkinter.getbusywaitinterval()
+        await asyncio.sleep(interval_ms / 1000)
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:


### PR DESCRIPTION
Hi, it's me again. I found another thing which might be worth improving.

The Tk main loop defines its sleep time via the parameter "getbusywaitinterval".

We could adjust our waiting time to that value (whose default is 20 ms and which can be configured) instead of using 10 ms as a fixed value.

(It turned out that it is a bad idea to push to a closed PR and only then reopen it. Sorry for the mess.)